### PR TITLE
Hagall chart update

### DIFF
--- a/charts/hagall/Chart.yaml
+++ b/charts/hagall/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hagall
 description: Distributed real-time networking server responsible for relaying events to connected clients in a space and channel in the Aukiverse
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.4"
 maintainers:
   - name: dataviruset

--- a/charts/hagall/Chart.yaml
+++ b/charts/hagall/Chart.yaml
@@ -3,6 +3,6 @@ name: hagall
 description: Distributed real-time networking server responsible for relaying events to connected clients in a space and channel in the Aukiverse
 type: application
 version: 0.1.0
-appVersion: "0.4.2"
+appVersion: "0.4"
 maintainers:
   - name: dataviruset

--- a/charts/hagall/templates/configmap.yaml
+++ b/charts/hagall/templates/configmap.yaml
@@ -6,6 +6,4 @@ metadata:
     {{- include "hagall.labels" . | nindent 4 }}
 data:
   HAGALL_ADDR: :8080
-  HAGALL_HDS_ENDPOINT: "https://hds.aukiverse.com"
-  HAGALL_EVENTS_ENDPOINT: "https://87cuuzjn40.execute-api.us-west-1.amazonaws.com/LogProd_serverless_lambda_stage/log"
   {{- toYaml .Values.config | nindent 2  }}

--- a/charts/hagall/values.yaml
+++ b/charts/hagall/values.yaml
@@ -45,7 +45,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
+    - host: hagall.example.com
       paths:
         - path: /
           pathType: ImplementationSpecific
@@ -70,17 +70,8 @@ affinity: {}
 
 config:
   HAGALL_LOG_LEVEL: info
-  HAGALL_SPACE_TIMEOUT: "2h"
-  HAGALL_SPACE_TIMEOUT_CHECK_INTERVAL: "5m"
-  HAGALL_SYNC_CLOCK_INTERVAL: "5s"
-  HAGALL_EVENTS_QUEUE_SIZE: "10000"
-  HAGALL_EVENTS_BATCH_SIZE: "100"
-  HAGALL_EVENTS_FLUSH_INTERVAL: "30s"
-  HAGALL_HDS_REGISTRATION_INTERVAL: "10s"
-  HAGALL_ENABLE_ODAL: "true"
-  HAGALL_ENABLE_VIKJA: "true"
-  HAGALL_ENABLE_POL: "true"
-  HAGALL_ENABLE_DAGAZ: "true"
+  HAGALL_WALLET_ADDR: 0x0
+  HAGALL_PUBLIC_ENDPOINT: "https://hagall.example.com"
 
 monitoring:
   namespace: monitoring

--- a/charts/hagall/values.yaml
+++ b/charts/hagall/values.yaml
@@ -70,7 +70,7 @@ affinity: {}
 
 config:
   HAGALL_LOG_LEVEL: info
-  HAGALL_WALLET_ADDR: 0x0
+  HAGALL_WALLET_ADDR: "0x0"
   HAGALL_PUBLIC_ENDPOINT: "https://hagall.example.com"
 
 monitoring:


### PR DESCRIPTION
Removes configs that normal users don't need to see. Full configuration can be obtained with `./hagall -h` and some examples can be seen in the documentation anyway: https://github.com/aukilabs/hagall/#configuration

Adds public endpoint config.