### PR TITLE
feat: PI-203 updated readiness endpoint

### DIFF
--- a/charts/hagall/Chart.yaml
+++ b/charts/hagall/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hagall
 description: Distributed, real-time networking server responsible for relaying messages among clients (participants) in posemesh sessions.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.5"
 maintainers:
   - name: dataviruset

--- a/charts/hagall/templates/deployment.yaml
+++ b/charts/hagall/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               port: admin
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: admin
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
This PR is to update Hagall readiness probe endpoint to `/ready`