### PR TITLE
feat: reconstruction-server api-key setting, deploy strategy, fixes

### DIFF
--- a/charts/domain-server/Chart.yaml
+++ b/charts/domain-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: domain-server
 description: The Domain Server is responsible for storing poses of portals in domains and spatial domain data such as scene reconstructions and occupancy maps.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.5"
 maintainers:
   - name: dataviruset

--- a/charts/domain-server/values.yaml
+++ b/charts/domain-server/values.yaml
@@ -49,6 +49,7 @@ envVars:
   DS_OPERATION_MODE: "public"
   DS_STORAGE_LOCAL_PATH: "./data/domain-data"
   DS_WALLET_PRIVATE_KEY_FILE_PATH: "/private-key-volume/wallet-private.key"
+  # DS_RECONSTRUCTION_SERVER_URL: "https://reconstruction-server.example.com"
 secrets:
   domain-server:
     as: environment
@@ -57,6 +58,8 @@ secrets:
         envVarName: DS_POSTGRES_URL
       registration_credentials:
         envVarName: DS_REGISTRATION_CREDENTIALS
+      # reconstruction_server_api_key:
+      #   envVarName: DS_RECONSTRUCTION_SERVER_API_KEY
   private-key-volume:
     as: volume
     mountPath: /private-key-volume

--- a/charts/reconstruction-server/Chart.yaml
+++ b/charts/reconstruction-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: reconstruction-server
 description: The Reconstruction Server runs local and global refinement pipelines for scene reconstruction, pose refinement and more.
 type: application
-version: 0.0.2
-appVersion: "0.1.33"
+version: 0.0.3
+appVersion: "0.1.34"
 maintainers:
   - name: dataviruset

--- a/charts/reconstruction-server/Chart.yaml
+++ b/charts/reconstruction-server/Chart.yaml
@@ -3,6 +3,6 @@ name: reconstruction-server
 description: The Reconstruction Server runs local and global refinement pipelines for scene reconstruction, pose refinement and more.
 type: application
 version: 0.0.3
-appVersion: "0.1.34"
+appVersion: "0.1.35"
 maintainers:
   - name: dataviruset

--- a/charts/reconstruction-server/templates/deployment.yaml
+++ b/charts/reconstruction-server/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
           volumeMounts:
             - name: shm
               mountPath: /dev/shm
+          args:
+            - "--api-key={{ .Values.apiKey }}"
+          # TODO: Change to env var + secret, or the reconstruction-server can validate domain access tokens instead
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/reconstruction-server/templates/deployment.yaml
+++ b/charts/reconstruction-server/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
           volumeMounts:
             - name: shm
               mountPath: /dev/shm
+            - name: jobs
+              mountPath: /app/jobs
           args:
             - "--api-key={{ .Values.apiKey }}"
           # TODO: Change to env var + secret, or the reconstruction-server can validate domain access tokens instead
@@ -71,3 +73,5 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: {{ .Values.shmSizeLimit }}
+        - name: jobs
+          emptyDir: {}

--- a/charts/reconstruction-server/templates/deployment.yaml
+++ b/charts/reconstruction-server/templates/deployment.yaml
@@ -5,6 +5,14 @@ metadata:
   labels:
     {{- include "reconstruction-server.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.deploymentStrategy.enabled }}
+  strategy:
+    type: {{ .Values.deploymentStrategy.type }}
+  {{- if and (eq .Values.deploymentStrategy.type "RollingUpdate") .Values.deploymentStrategy.rollingUpdate }}
+    rollingUpdate:
+  {{ toYaml .Values.deploymentStrategy.rollingUpdate | indent 6 }}
+  {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "reconstruction-server.selectorLabels" . | nindent 6 }}

--- a/charts/reconstruction-server/values.yaml
+++ b/charts/reconstruction-server/values.yaml
@@ -98,3 +98,7 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
+
+deploymentStrategy:
+  enabled: true
+  type: Recreate

--- a/charts/reconstruction-server/values.yaml
+++ b/charts/reconstruction-server/values.yaml
@@ -89,7 +89,7 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext:
-  fsGroup: 2000
+  fsGroup: 1000
 
 securityContext:
   capabilities:

--- a/charts/reconstruction-server/values.yaml
+++ b/charts/reconstruction-server/values.yaml
@@ -33,6 +33,9 @@ affinity: {}
 # Set the /dev/shm (shared memory) size limit
 shmSizeLimit: 512Mi
 
+# Set an API key here and configure the DMT app or domain-server to use it
+apiKey: ""
+
 containerPorts:
   app:
     port: 8080


### PR DESCRIPTION
The reconstruction-server should ideally validate incoming requests by checking domain access tokens in the future.
Another possible intermediate solution is to use environment variables and secrets instead. But this method also works for now before we change to something more secure.