### PR TITLE
fix: reconstruction-server emptydir for home and tmp folders

### DIFF
--- a/charts/reconstruction-server/Chart.yaml
+++ b/charts/reconstruction-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: reconstruction-server
 description: The Reconstruction Server runs local and global refinement pipelines for scene reconstruction, pose refinement and more.
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: "0.1.35"
 maintainers:
   - name: dataviruset

--- a/charts/reconstruction-server/templates/deployment.yaml
+++ b/charts/reconstruction-server/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
               mountPath: /dev/shm
             - name: jobs
               mountPath: /app/jobs
+            - name: home
+              mountPath: /home/reconstruction-server
+            - name: tmp
+              mountPath: /tmp
           args:
             - "--api-key={{ .Values.apiKey }}"
           # TODO: Change to env var + secret, or the reconstruction-server can validate domain access tokens instead
@@ -74,4 +78,8 @@ spec:
             medium: Memory
             sizeLimit: {{ .Values.shmSizeLimit }}
         - name: jobs
+          emptyDir: {}
+        - name: home
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}


### PR DESCRIPTION
Needed to avoid disabling `readOnlyRootFilesystem`.