### PR TITLE
feat: DS autoscalers and kind selection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,23 +17,21 @@ jobs:
           - kind_version: v0.22.0
             k8s_version: v1.23.17
     steps:
-      - name: Checkout
+      - name: Check out the repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.13.2
+        uses: azure/setup-helm@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.x'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -47,7 +45,7 @@ jobs:
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@v1
         if: steps.list-changed.outputs.changed == 'true'
         with:
           version: ${{ matrix.kind_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,13 @@ jobs:
       max-parallel: 4
       matrix:
         # https://github.com/kubernetes-sigs/kind/releases
-        kind_version: [v0.20.0]
-        k8s_version: [v1.28.0, v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17, v1.22.17, v1.21.14]
+        kind_version: [v0.30.0]
+        k8s_version: [v1.34.0, v1.33.4, v1.32.8, v1.31.12]
         include:
-          - kind_version: v0.17.0
-            k8s_version: v1.20.15
-          - kind_version: v0.17.0
-            k8s_version: v1.19.16
+          - kind_version: v0.22.0
+            k8s_version: v1.29.2
+          - kind_version: v0.22.0
+            k8s_version: v1.23.17
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/charts/domain-server/Chart.yaml
+++ b/charts/domain-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: domain-server
 description: The Domain Server is responsible for storing poses of portals in domains and spatial domain data such as scene reconstructions and occupancy maps.
 type: application
-version: 0.4.1
-appVersion: "0.5"
+version: 0.5.0
+appVersion: "0.6"
 maintainers:
   - name: dataviruset
 dependencies:

--- a/charts/domain-server/templates/deployment.yaml
+++ b/charts/domain-server/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (index .Values "juicefs-s3-gateway" "enabled") (eq .Values.forceStatefulSet false) }}
+{{- if eq .Values.kind "Deployment" }}
 {{- $secrets := .Values.secrets }}
 {{- $hasVolumeSecret := false }}
 {{- $fullName := include "domain-server.fullname" . }}

--- a/charts/domain-server/templates/hpa.yaml
+++ b/charts/domain-server/templates/hpa.yaml
@@ -1,12 +1,12 @@
 {{- if and (eq .Values.kind "Deployment") .Values.autoscaling.hpa.enabled }}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "domain-server.fullname" . }}
   labels:
     {{- include "domain-server.labels" . | nindent 4 }}
-{{- if .Values.service.annotations }}
-{{- with .Values.service.annotations }}
+{{- if .Values.autoscaling.hpa.annotations }}
+{{- with .Values.autoscaling.hpa.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/domain-server/templates/hpa.yaml
+++ b/charts/domain-server/templates/hpa.yaml
@@ -1,0 +1,38 @@
+{{- if and (eq .Values.kind "Deployment") .Values.autoscaling.hpa.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "domain-server.fullname" . }}
+  labels:
+    {{- include "domain-server.labels" . | nindent 4 }}
+{{- if .Values.service.annotations }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "domain-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.hpa.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
+    {{- end }}
+    {{- if .Values.autoscaling.hpa.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
+    {{- end }}
+{{- end }}

--- a/charts/domain-server/templates/service.yaml
+++ b/charts/domain-server/templates/service.yaml
@@ -1,7 +1,3 @@
-{{- /*
-If the operator configures the service input variable, then also create a Service resource that exposes the Pod as a
-stable endpoint that can be routed within the Kubernetes cluster.
-*/ -}}
 {{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service

--- a/charts/domain-server/templates/statefulset.yaml
+++ b/charts/domain-server/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.forceStatefulSet true) (eq (index .Values "juicefs-s3-gateway" "enabled") false) }}
+{{- if eq .Values.kind "StatefulSet" }}
 {{- $secrets := .Values.secrets }}
 {{- $hasVolumeSecret := false }}
 {{- $fullName := include "domain-server.fullname" . }}

--- a/charts/domain-server/templates/vpa.yaml
+++ b/charts/domain-server/templates/vpa.yaml
@@ -1,0 +1,40 @@
+{{- if and (eq .Values.kind "Deployment") .Values.autoscaling.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "domain-server.fullname" . }}
+  labels:
+    {{- include "domain-server.labels" . | nindent 4 }}
+{{- if .Values.service.annotations }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ .Values.applicationName }}
+      {{- with .Values.autoscaling.vpa.controlledResources }}
+      controlledResources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.autoscaling.vpa.maxAllowed }}
+      maxAllowed:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.autoscaling.vpa.minAllowed }}
+      minAllowed:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: "Deployment"
+    name: {{ include "domain-server.fullname" . }}
+  {{- if .Values.autoscaling.vpa.updatePolicy }}
+  updatePolicy:
+    {{- with .Values.autoscaling.vpa.updatePolicy.updateMode }}
+    updateMode: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/domain-server/templates/vpa.yaml
+++ b/charts/domain-server/templates/vpa.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ include "domain-server.fullname" . }}
   labels:
     {{- include "domain-server.labels" . | nindent 4 }}
-{{- if .Values.service.annotations }}
-{{- with .Values.service.annotations }}
+{{- if .Values.autoscaling.vpa.annotations }}
+{{- with .Values.autoscaling.vpa.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/domain-server/values.yaml
+++ b/charts/domain-server/values.yaml
@@ -4,7 +4,12 @@ containerImage:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 applicationName: domain-server
-forceStatefulSet: false
+# kind can be StatefulSet or Deployment
+# Deployment requires an S3-compatible storage backend to be configured and
+# we recommend also enabling juicefs-s3-gateway. With JuiceFS, other non-S3 backends
+# can be used. See juicefs-s3-gateway section below.
+kind: StatefulSet
+replicaCount: 2 # only applicable for Deployment kind
 tolerations:
   - key: "dedicated"
     value: "armGroup"

--- a/charts/domain-server/values.yaml
+++ b/charts/domain-server/values.yaml
@@ -3,17 +3,23 @@ containerImage:
   repository: aukilabs/domain-server
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+
 applicationName: domain-server
+
 # kind can be StatefulSet or Deployment
 # Deployment requires an S3-compatible storage backend to be configured and
 # we recommend also enabling juicefs-s3-gateway. With JuiceFS, other non-S3 backends
 # can be used. See juicefs-s3-gateway section below.
 kind: StatefulSet
-replicaCount: 2 # only applicable for Deployment kind
+
+# only applicable for Deployment kind
+replicaCount: 2
+
 tolerations:
   - key: "dedicated"
     value: "armGroup"
     effect: "NoSchedule"
+
 containerPorts:
   http:
     port: 8080
@@ -21,6 +27,7 @@ containerPorts:
   admin:
     port: 18190
     protocol: TCP
+
 service:
   enabled: true
   ports:
@@ -32,6 +39,7 @@ service:
       port: 18190
       targetPort: 18190
       protocol: TCP
+
 # affinity:
 #   podAntiAffinity:
 #     requiredDuringSchedulingIgnoredDuringExecution:
@@ -42,6 +50,7 @@ service:
 #               values:
 #                 - domain-server-s3
 #         topologyKey: kubernetes.io/hostname
+
 ingress:
   enabled: false
   # className: nginx
@@ -63,6 +72,7 @@ ingress:
   #   - secretName: chart-example-tls
   #     hosts:
   #       - chart-example.local
+
 envVars:
   DS_ADDR: ":8080"
   DS_ADMIN_ADDR: ":18190"
@@ -77,6 +87,7 @@ envVars:
 #  DS_DEFAULT_REQUEST_TIMEOUT: "600s" # 10 minutes
 #  DS_STREAM_REQUEST_TIMEOUT: "600s" # 10 minutes
 #  DS_RECONSTRUCTION_SERVER_URL: "https://reconstruction-server.example.com"
+
 secrets:
   domain-server:
     as: environment
@@ -101,6 +112,7 @@ containerResources:
   requests:
     memory: 256Mi
     cpu: 1
+
 monitoring:
   namespace: monitoring
   podMonitor:

--- a/charts/domain-server/values.yaml
+++ b/charts/domain-server/values.yaml
@@ -211,6 +211,7 @@ persistentVolume:
         updateMode: Auto
     hpa:
       enabled: false
+      annotations: {}
       minReplicas: ""
       maxReplicas: ""
       ## Target CPU utilization percentage

--- a/charts/domain-server/values.yaml
+++ b/charts/domain-server/values.yaml
@@ -185,6 +185,41 @@ persistentVolume:
   ##
   # volumeName: ""
 
+  ## Autoscaling configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  autoscaling:
+    vpa:
+      enabled: false
+      annotations: {}
+      ## List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+      ##
+      controlledResources: []
+      ## Max allowed resources for the pod
+      ## cpu: 200m
+      ## memory: 100Mi
+      maxAllowed: {}
+      ## Min allowed resources for the pod
+      ## cpu: 200m
+      ## memory: 100Mi
+      minAllowed: {}
+      ## VPA update policy
+      ##
+      updatePolicy:
+        ## Autoscaling update policy Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod
+        ## Possible values are "Off", "Initial", "Recreate", and "Auto".
+        ##
+        updateMode: Auto
+    hpa:
+      enabled: false
+      minReplicas: ""
+      maxReplicas: ""
+      ## Target CPU utilization percentage
+      ##
+      targetCPU: ""
+      ## Target Memory utilization percentage
+      ##
+      targetMemory: ""
+
 # See https://github.com/bitnami/charts/blob/postgresql/15.4.2/bitnami/postgresql/values.yaml
 postgresql:
   # If true, the PostgreSQL dependency is enabled


### PR DESCRIPTION
* Adds support for HPA and VPA autoscalers
* Allows operators to choose whether DS should be deployed as a Deployment or StatefulSet regardless of whether JuiceFS is enabled or not
* Bumps chart minor version (instead of patch version below 1.0.0) as the `kind:` selection is a breaking change
* Also fixes DS image tag to default to v0.6 instead of v0.5

GitHub Actions depends on that the 0.6 image tag has been released and is available on Docker Hub.